### PR TITLE
Fix README.md github repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Please note that this plugin was created more or less as a joke. I mainly wanted
 Installation is supported via `hyprpm`. Supported hyprland versions are `v0.41.2` and upwards. The main branch generally tries to target `-git`.
 
 ```sh
-hyprpm add https://github.com/virtcode/hypr-dynamic-cursors
+hyprpm add https://github.com/virtcode/hypr-dynamic-cursors.git
 hyprpm enable dynamic-cursors
 ```
 


### PR DESCRIPTION
Running the following command doesn't work as it is not a valid git repository:
```sh
❯ hyprpm add https://github.com/virtcode/hypr-dynamic-cursors

 → Cloning https://github.com/virtcode/hypr-dynamic-cursors
 ╍━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  0 / 5  Cloning the plugin repository
✖ Could not clone the plugin repository. shell returned:
Cloning into 'dani'...
fatal: unable to access 'https://github.com/virtcode/hypr-dynamic-cursors/': Could not resolve host: github.com

✖ Couldn't enable plugin (missing?)
```

The fix would be to add the .git extension to the repository url.