### PR TITLE
fix: fix building of hyprland plugin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
       in
         stdenvNoCC.mkDerivation {
           inherit name;
+          pname = name;
           src = ./.;
 
           inherit (hyprland) buildInputs;


### PR DESCRIPTION
Hyprland needs pname,
fixes #32.