### PR TITLE
Improve: Guard against divide by 0 in various cursor effects.

### DIFF
--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -33,7 +33,9 @@ void tickRaw(SP<CEventLoopTimer> self, void* data) {
     if (isEnabled())
         g_pDynamicCursors->onTick(g_pPointerManager.get());
 
-    const int TIMEOUT = g_pHyprRenderer->m_pMostHzMonitor ? 1000.0 / g_pHyprRenderer->m_pMostHzMonitor->refreshRate : 16;
+    const int TIMEOUT = g_pHyprRenderer->m_pMostHzMonitor && g_pHyprRenderer->m_pMostHzMonitor->refreshRate > 0 
+        ? 1000.0 / g_pHyprRenderer->m_pMostHzMonitor->refreshRate 
+        : 16;
     self->updateTimeout(std::chrono::milliseconds(TIMEOUT));
 }
 

--- a/src/mode/ModeStretch.cpp
+++ b/src/mode/ModeStretch.cpp
@@ -15,7 +15,7 @@ SModeResult CModeStretch::update(Vector2D pos) {
     auto limit = g_pShapeRuleHandler->getIntOr(CONFIG_STRETCH_LIMIT, **PLIMIT);
 
     // create samples array
-    int max = g_pHyprRenderer->m_pMostHzMonitor->refreshRate / 10; // 100ms worth of history
+    int max = std::max(1, (int)(g_pHyprRenderer->m_pMostHzMonitor->refreshRate / 10)); // 100ms worth of history, avoiding divide by 0
     samples.resize(max, pos);
 
     // capture current sample

--- a/src/mode/ModeTilt.cpp
+++ b/src/mode/ModeTilt.cpp
@@ -15,7 +15,7 @@ SModeResult CModeTilt::update(Vector2D pos) {
     auto limit = g_pShapeRuleHandler->getIntOr(CONFIG_TILT_LIMIT, **PLIMIT);
 
     // create samples array
-    int max = g_pHyprRenderer->m_pMostHzMonitor->refreshRate / 10; // 100ms worth of history
+    int max = std::max(1, (int)(g_pHyprRenderer->m_pMostHzMonitor->refreshRate / 10)); // 100ms worth of history, avoiding divide by 0
     samples.resize(max, pos);
 
     // capture current sample

--- a/src/other/Shake.cpp
+++ b/src/other/Shake.cpp
@@ -44,7 +44,7 @@ double CShake::update(Vector2D pos) {
 
     static auto* const* PIPC = (Hyprlang::INT* const*) getConfig(CONFIG_SHAKE_IPC);
 
-    int max = g_pHyprRenderer->m_pMostHzMonitor->refreshRate; // 1s worth of history
+    int max = std::max(1, (int)(g_pHyprRenderer->m_pMostHzMonitor->refreshRate)); // 1s worth of history, avoiding divide by 0
     samples.resize(max);
     samples_distance.resize(max);
 


### PR DESCRIPTION
fixes #67 

- https://github.com/VirtCode/hypr-dynamic-cursors/issues/67

This adds safety guards to prevent a division by 0 when the refresh rate is very low.
In my case, it fixes post suspend crashes.