### PR TITLE
Makefile split build to enable parallel builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,27 @@
 PLUGIN_NAME=dynamic-cursors
 
-SOURCE_FILES=$(wildcard ./src/*.cpp ./src/*/*.cpp)
+SOURCE_FILES := $(wildcard ./src/*.cpp ./src/*/*.cpp)
+OBJECT_FILES := $(patsubst ./src/%.cpp, out/%.o, $(SOURCE_FILES))
+CXX_FLAGS := -Wall --no-gnu-unique -fPIC -std=c++26 -g \
+	$(shell pkg-config --cflags hyprland | awk '{print $$NF "/src";}') \
+	$(shell pkg-config --cflags pixman-1 libdrm hyprland)
+
 OUTPUT=out/$(PLUGIN_NAME).so
 
 .PHONY: all clean load unload
 
 all: $(OUTPUT)
 
-$(OUTPUT): $(SOURCE_FILES)
-	mkdir -p out
-	$(CXX) -shared -Wall --no-gnu-unique -fPIC $(SOURCE_FILES) -g `pkg-config --cflags hyprland | awk '{print $$NF "/src";}'` `pkg-config --cflags pixman-1 libdrm hyprland` -std=c++26 -o $(OUTPUT)
+$(OUTPUT): $(OBJECT_FILES)
+	$(CXX) -shared $^ -o $@
+
+# Compile step (object file per .cpp)
+out/%.o: ./src/%.cpp
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXX_FLAGS) -c $< -o $@
 
 clean:
-	rm -f $(OUTPUT)
+	$(RM) $(OUTPUT) $(OBJECT_FILES)
 
 load: all unload
 	hyprctl plugin load ${PWD}/$(OUTPUT)

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,7 @@
 
           inherit (hyprland) buildInputs;
           nativeBuildInputs = hyprland.nativeBuildInputs ++ [hyprland gcc14];
+          enableParallelBuilding = true;
 
           dontUseCmakeConfigure = true;
           dontUseMesonConfigure = true;
@@ -40,7 +41,7 @@
             runHook preInstall
 
             mkdir -p "$out/lib"
-            cp -r out/* "$out/lib/lib${name}.so"
+            cp -r out/dynamic-cursors.so "$out/lib/lib${name}.so"
 
             runHook postInstall
           '';


### PR DESCRIPTION
I tried to fork this repo and got stuck at slow 1-thread uncached build speed.

I added targets for `.o` files in the `./out` directory, so each `.cpp` can be built in its own thread.

Also set the mkDerivation { enableParallelBuilding } flag. Not sure if it's required, but it works for me.