### PR TITLE
Fix race condition in config reload causing crashes

### DIFF
--- a/src/highres.cpp
+++ b/src/highres.cpp
@@ -33,7 +33,7 @@ static void hcLogger(enum eHyprcursorLogLevel level, char* message) {
 }
 
 void CHighresHandler::update() {
-    std::lock_guard<std::mutex> lock(updateMutex);
+    std::lock_guard<std::recursive_mutex> lock(updateMutex);
 
     static auto* const* PENABLED = (Hyprlang::INT* const*) getConfig(CONFIG_HIGHRES_ENABLED);
     static auto* const* PUSEHYPRCURSOR = (Hyprlang::INT* const*) getHyprlandConfig("cursor:enable_hyprcursor");
@@ -104,7 +104,7 @@ void CHighresHandler::update() {
 }
 
 void CHighresHandler::loadShape(const std::string& name) {
-    std::lock_guard<std::mutex> lock(updateMutex);
+    std::lock_guard<std::recursive_mutex> lock(updateMutex);
 
     static auto const* PFALLBACK = (Hyprlang::STRING const*) getConfig(CONFIG_HIGHRES_FALLBACK);
 

--- a/src/highres.cpp
+++ b/src/highres.cpp
@@ -28,13 +28,11 @@ CHighresHandler::CHighresHandler() {
 static void hcLogger(enum eHyprcursorLogLevel level, char* message) {
     if (level == HC_LOG_TRACE) return;
     // Copy message to avoid race condition when called from background thread
-    std::string safe_message(message ? message : "");
-    Debug::log(NONE, "[hc (dynamic)] {}", safe_message);
+    std::string msg(message ? message : "");
+    Debug::log(NONE, "[hc (dynamic)] {}", msg);
 }
 
 void CHighresHandler::update() {
-    std::lock_guard<std::recursive_mutex> lock(updateMutex);
-
     static auto* const* PENABLED = (Hyprlang::INT* const*) getConfig(CONFIG_HIGHRES_ENABLED);
     static auto* const* PUSEHYPRCURSOR = (Hyprlang::INT* const*) getHyprlandConfig("cursor:enable_hyprcursor");
     static auto* const* PSIZE = (Hyprlang::INT* const*) getConfig(CONFIG_HIGHRES_SIZE);
@@ -104,8 +102,6 @@ void CHighresHandler::update() {
 }
 
 void CHighresHandler::loadShape(const std::string& name) {
-    std::lock_guard<std::recursive_mutex> lock(updateMutex);
-
     static auto const* PFALLBACK = (Hyprlang::STRING const*) getConfig(CONFIG_HIGHRES_FALLBACK);
 
     if (!manager) {

--- a/src/highres.hpp
+++ b/src/highres.hpp
@@ -23,7 +23,7 @@ public:
 
 private:
     bool enabled = true;
-    std::mutex updateMutex; // Protect against race conditions during config reload
+    std::recursive_mutex updateMutex; // Protect against race conditions during config reload (recursive for update->loadShape->update)
 
     Hyprcursor::SCursorStyleInfo style;
 

--- a/src/highres.hpp
+++ b/src/highres.hpp
@@ -1,4 +1,5 @@
 #include <future>
+#include <mutex>
 #include <hyprland/src/managers/CursorManager.hpp>
 #include <hyprland/src/render/Texture.hpp>
 #include <hyprland/src/helpers/memory/Memory.hpp>
@@ -22,6 +23,7 @@ public:
 
 private:
     bool enabled = true;
+    std::mutex updateMutex; // Protect against race conditions during config reload
 
     Hyprcursor::SCursorStyleInfo style;
 

--- a/src/highres.hpp
+++ b/src/highres.hpp
@@ -1,5 +1,4 @@
 #include <future>
-#include <mutex>
 #include <hyprland/src/managers/CursorManager.hpp>
 #include <hyprland/src/render/Texture.hpp>
 #include <hyprland/src/helpers/memory/Memory.hpp>
@@ -23,7 +22,6 @@ public:
 
 private:
     bool enabled = true;
-    std::recursive_mutex updateMutex; // Protect against race conditions during config reload (recursive for update->loadShape->update)
 
     Hyprcursor::SCursorStyleInfo style;
 


### PR DESCRIPTION
- Copy message string in hcLogger to avoid use-after-free
- Add mutex protection for update() and loadShape() methods
- Prevents memory corruption during concurrent config reload and cursor loading

Fixes VirtCode/hypr-dynamic-cursors#99