### PR TITLE
chore: fix clang panicking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PLUGIN_NAME=dynamic-cursors
 
 SOURCE_FILES := $(wildcard ./src/*.cpp ./src/*/*.cpp)
 OBJECT_FILES := $(patsubst ./src/%.cpp, out/%.o, $(SOURCE_FILES))
-CXX_FLAGS := -Wall --no-gnu-unique -fPIC -std=c++26 -g \
+CXX_FLAGS := -Wall -fPIC -std=c++26 -g \
 	$(shell pkg-config --cflags hyprland | awk '{print $$NF "/src";}') \
 	$(shell pkg-config --cflags pixman-1 libdrm hyprland)
 


### PR DESCRIPTION
remove that arg so clang can compile in peace