### PR TITLE
Cleanup Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,13 @@ PLUGIN_NAME=dynamic-cursors
 
 SOURCE_FILES := $(wildcard ./src/*.cpp ./src/*/*.cpp ./src/*/*/*.cpp)
 OBJECT_FILES := $(patsubst ./src/%.cpp, out/%.o, $(SOURCE_FILES))
-CXX_FLAGS := -Wall -fPIC -std=c++26 -g \
+CXXFLAGS := -Wall -fPIC -std=c++26 -g \
 	$(shell pkg-config --cflags hyprland pixman-1 libdrm | sed 's#-I\([^ ]*/hyprland\)\($$\| \)#-I\1 -I\1/src #g')
 
 OUTPUT=out/$(PLUGIN_NAME).so
 
 ifeq ($(CXX),g++)
-    EXTRA_FLAGS = --no-gnu-unique
-else
-    EXTRA_FLAGS =
+    CXXFLAGS += --no-gnu-unique
 endif
 
 .PHONY: all clean load unload
@@ -18,12 +16,12 @@ endif
 all: $(OUTPUT)
 
 $(OUTPUT): $(OBJECT_FILES)
-	$(CXX) -shared $^ -o $@
+	$(CXX) -shared $^ $(LDFLAGS) -o $@
 
 # Compile step (object file per .cpp)
 out/%.o: ./src/%.cpp
 	@mkdir -p $(dir $@)
-	$(CXX) $(CXX_FLAGS) $(LDFLAGS) $(EXTRA_FLAGS) -c $< -o $@
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(EXTRA_CXXFLAGS) -c $< -o $@
 
 clean:
 	$(RM) $(OUTPUT) $(OBJECT_FILES)


### PR DESCRIPTION
Support passing `CXXFLAGS` from outside

pls check on g++ that the `--no-gnu-unique` flag still gets added correctly, I can't check that on my system.