### PR TITLE
fix: remove HyprlandAPI::reloadConfig() from PLUGIN_INIT to prevent reload cycle race

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -177,7 +177,6 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 
     // setup config
     g_pConfigHandler = makeUnique<CConfigHandler>();
-    HyprlandAPI::reloadConfig();
 
     // init things
     g_pDynamicCursors = makeUnique<CDynamicCursors>();


### PR DESCRIPTION
`HyprlandAPI::reloadConfig()` in `PLUGIN_INIT` triggers a redundant config reload while the compositor is still initializing. With Hyprland 0.55+ and Lua configs, plugins should be loaded via `hl.plugin.load()` — Hyprland's `handlePluginLoads()` already calls `reload()` automatically after loading the plugin.

The extra `reloadConfig()` from `PLUGIN_INIT` creates a conflicting reload cycle: the plugin init triggers a reload, which triggers `handlePluginLoads()` again, which calls `reload()` again. This race can cause a SIGSEGV in `CEventLoopManager::onTimerFireEv` when the Lua config file is edited while Hyprland is running.

Removing the call lets Hyprland manage the reload lifecycle naturally.
